### PR TITLE
Added srecord utility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,3 +33,7 @@ RUN apt-get -y install python-dev libffi-dev libssl-dev libxml2-dev
 # ------------------------------------------------------------------------------
 # Install yotta
 RUN pip install -U pyopenssl ndg-httpsclient pyasn1 requests yotta==0.14.1
+
+# ------------------------------------------------------------------------------
+# Install srecord
+RUN apt-get -y install srecord


### PR DESCRIPTION
When building for the BBC Micro:bit following the guide located here with Yotta in a Docker. 

http://www.i-programmer.info/programming/hardware/9654-offline-cc-development-with-the-microbit-.html?start=1

The build fails with `srec_cat: not found`. Adding `srecord` to the Docker image fixed the issue and suggest it is added here. 
